### PR TITLE
Updating integrated Docker registry command

### DIFF
--- a/getting_started/administrators.adoc
+++ b/getting_started/administrators.adoc
@@ -271,7 +271,7 @@ $ oc project default
 . Set up an integrated Docker registry for the {product-title} cluster:
 +
 ----
-$ oadm registry --credentials=./openshift.local.config/master/openshift-registry.kubeconfig
+$ oadm registry --config=./openshift.local.config/master/admin.kubeconfig --service-account=registry
 ----
 +
 It will take a few minutes for the registry image to download and start - use


### PR DESCRIPTION
Copying the registry deployment instructions from [install_config/registry/deploy_registry_existing_clusters.adoc](https://docs.openshift.org/latest/install_config/registry/deploy_registry_existing_clusters.html) and stopping use of deprecated `--credentials` -option.